### PR TITLE
feat: Add sitemap and robots.txt for Google Search indexing

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://madeforx.com/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,48 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://madeforx.com',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: 'https://madeforx.com/mail-generator',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://madeforx.com/mail-generator/reply',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: 'https://madeforx.com/mail-generator/chat',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: 'https://madeforx.com/shipping-calculator',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://madeforx.com/waste-collection',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://madeforx.com/japanpost',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- Add sitemap.ts with all main pages and subpages for Google Search Console
- Add robots.ts to allow search engine crawling and indexing
- Enable proper SEO discovery of all site features

## Test plan
- [ ] Verify sitemap.xml is accessible at /sitemap.xml after deployment
- [ ] Verify robots.txt is accessible at /robots.txt after deployment
- [ ] Submit sitemap to Google Search Console for indexing

🤖 Generated with [Claude Code](https://claude.ai/code)