### PR TITLE
fix: Add proper www to non-www redirect configuration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,9 +39,6 @@ export const metadata: Metadata = {
     telephone: false,
   },
   metadataBase: new URL('https://madeforx.com'),
-  alternates: {
-    canonical: '/',
-  },
   openGraph: {
     title: 'Made for X - 便利なツールとサービス',
     description:

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,17 @@
 {
   "buildCommand": "npm run build",
-  "installCommand": "npm install && npx prisma generate && npx prisma migrate deploy && npm run db:seed:prod"
+  "installCommand": "npm install && npx prisma generate && npx prisma migrate deploy && npm run db:seed:prod",
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.madeforx.com"
+        }
+      ],
+      "destination": "https://madeforx.com/$1",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
- Add Vercel redirect configuration to handle www.madeforx.com → madeforx.com
- Remove redundant alternates.canonical from layout.tsx (Next.js handles this with metadataBase)
- Ensures proper canonical URL handling and prevents duplicate content issues

The Google Search Console message about "alternate page with proper canonical" is expected behavior - it means Google correctly identifies www as an alternate and only indexes the canonical non-www version.

🤖 Generated with Claude Code