### PR TITLE
fix: Separate chat feature NEW tag logic and fix break timer sleep behavior

### DIFF
--- a/src/utils/feature-notifications.ts
+++ b/src/utils/feature-notifications.ts
@@ -3,6 +3,9 @@
 // Privacy policy update date
 export const PRIVACY_POLICY_UPDATE_DATE = '2025-07-23';
 
+// Chat feature release date (for NEW tag display)
+export const CHAT_FEATURE_RELEASE_DATE = '2025-07-23';
+
 // Number of days to show the update notification
 export const UPDATE_NOTIFICATION_DAYS = 60;
 
@@ -22,10 +25,16 @@ export function shouldShowUpdateNotification(): boolean {
 
 /**
  * Check if the "NEW" tag for chat feature should be shown
- * @returns true if within 60 days of the update date (same as update notification)
+ * @returns true if within 60 days of the chat feature release date
  */
 export function shouldShowNewTag(): boolean {
-  return shouldShowUpdateNotification();
+  const releaseDate = new Date(CHAT_FEATURE_RELEASE_DATE);
+  const currentDate = new Date();
+  const daysDifference = Math.floor(
+    (currentDate.getTime() - releaseDate.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  return daysDifference >= 0 && daysDifference <= UPDATE_NOTIFICATION_DAYS;
 }
 
 /**


### PR DESCRIPTION
## Changes
- ✅ Fixed NEW tag incorrectly reusing privacy policy date
- ✅ Implemented timestamp-based timer for accurate counting during display sleep
- ✅ Set CHAT_FEATURE_RELEASE_DATE to match privacy policy date (2025-07-23)

## Bug Fixes

### Bug 1: NEW Tag Display
- **Problem:** NEW tag reused privacy policy update date logic
- **Solution:** Created separate `CHAT_FEATURE_RELEASE_DATE` constant with independent calculation
- **Files:** `src/utils/feature-notifications.ts`

### Bug 2: Break Timer Sleep Behavior
- **Problem:** Timer stopped counting when display sleeps or tab becomes inactive
- **Solution:** Timestamp-based calculation instead of interval countdown
- **Implementation:**
  - Added `startTimestamp` state to track when timer started
  - Calculate remaining time from elapsed milliseconds
  - Update interval: 100ms for smooth display
  - Added `useMemo` to prevent unnecessary re-renders
- **Files:** `src/components/Break/BreakTimer.tsx`

## Technical Details

### Before (Interval-based)
```typescript
setInterval(() => {
  setTimeLeft((time) => time - 1);
}, 1000);
```
**Issue:** Browser pauses interval when display sleeps

### After (Timestamp-based)
```typescript
const elapsedSeconds = Math.floor((Date.now() - startTimestamp) / 1000);
const remaining = modes[mode].duration - elapsedSeconds;
setTimeLeft(remaining);
```
**Solution:** Timer continues counting accurately even during sleep

## Testing
- [x] Lint passed
- [x] Format applied
- [x] Build successful
- [ ] Manual testing: Display sleep behavior
- [ ] Manual testing: Tab switching behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)