### PR TITLE
fix(share): always-dropdown share + X card unfurl + a11y fixes

### DIFF
--- a/src/app/holidays/opengraph-image.tsx
+++ b/src/app/holidays/opengraph-image.tsx
@@ -1,0 +1,233 @@
+import { ImageResponse } from 'next/og';
+import { getNextHoliday } from '@/lib/holidays/holidays';
+import { calculateBridgePlan } from '@/lib/holidays/bridge-calculator';
+import holiday_jp from '@holiday-jp/holiday_jp';
+import { Holiday } from '@/lib/holidays/types';
+
+export const runtime = 'edge';
+
+export const alt = '次の祝日カウントダウン・連休プランナー';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatDate(date: Date): string {
+  const days = ['日', '月', '火', '水', '木', '金', '土'];
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const dow = days[date.getDay()];
+  return `${y}年${m}月${d}日（${dow}）`;
+}
+
+function formatShortRange(start: Date, end: Date): string {
+  const days = ['日', '月', '火', '水', '木', '金', '土'];
+  const fmt = (date: Date) => `${date.getMonth() + 1}/${date.getDate()}（${days[date.getDay()]}）`;
+  return `${fmt(start)} 〜 ${fmt(end)}`;
+}
+
+function daysUntil(target: Date): number {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfTarget = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const diff = startOfTarget.getTime() - startOfToday.getTime();
+  return Math.max(0, Math.round(diff / (1000 * 60 * 60 * 24)));
+}
+
+function getAllHolidays(): Holiday[] {
+  const now = new Date();
+  const twoYears = new Date(now);
+  twoYears.setFullYear(twoYears.getFullYear() + 2);
+  return holiday_jp
+    .between(now, twoYears)
+    .map((h: { date: Date; name: string; name_en: string }) => ({
+      date: h.date,
+      name: h.name,
+      nameEn: h.name_en,
+    }));
+}
+
+export default async function OpenGraphImage() {
+  const holiday = getNextHoliday();
+  const plan = holiday ? calculateBridgePlan(holiday.date, getAllHolidays()) : null;
+  const days = holiday ? daysUntil(holiday.date) : null;
+  const ptoLabel = plan
+    ? plan.ptoDaysNeeded > 0
+      ? `有給${plan.ptoDaysNeeded}日で ${formatShortRange(plan.startDate, plan.endDate)}`
+      : formatShortRange(plan.startDate, plan.endDate)
+    : '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          backgroundImage: 'linear-gradient(135deg, #e0f2fe 0%, #dbeafe 100%)',
+          padding: '60px 80px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 48,
+              height: 48,
+              borderRadius: 10,
+              backgroundColor: '#1f2937',
+              color: 'white',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 26,
+              fontWeight: 700,
+            }}
+          >
+            X
+          </div>
+          <div style={{ fontSize: 30, color: '#1f2937', fontWeight: 600, display: 'flex' }}>
+            Made for X
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {holiday && plan && days !== null ? (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 30,
+                  color: '#475569',
+                  display: 'flex',
+                  marginBottom: 8,
+                }}
+              >
+                次の祝日
+              </div>
+              <div
+                style={{
+                  fontSize: 90,
+                  fontWeight: 800,
+                  color: '#0f172a',
+                  display: 'flex',
+                  marginBottom: 8,
+                }}
+              >
+                🎌 {holiday.name}
+              </div>
+              <div
+                style={{
+                  fontSize: 34,
+                  color: '#334155',
+                  display: 'flex',
+                  marginBottom: 36,
+                }}
+              >
+                {formatDate(holiday.date)}
+              </div>
+
+              <div style={{ display: 'flex', gap: 32 }}>
+                <div
+                  style={{
+                    backgroundColor: 'white',
+                    borderRadius: 24,
+                    padding: '24px 56px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    boxShadow: '0 4px 6px rgba(0,0,0,0.05)',
+                  }}
+                >
+                  <div style={{ fontSize: 22, color: '#64748b', display: 'flex' }}>あと</div>
+                  <div
+                    style={{
+                      fontSize: 96,
+                      fontWeight: 800,
+                      color: '#1d4ed8',
+                      lineHeight: 1,
+                      display: 'flex',
+                    }}
+                  >
+                    {days}
+                  </div>
+                  <div style={{ fontSize: 22, color: '#64748b', display: 'flex' }}>日</div>
+                </div>
+
+                <div
+                  style={{
+                    backgroundColor: 'white',
+                    borderRadius: 24,
+                    padding: '24px 40px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    boxShadow: '0 4px 6px rgba(0,0,0,0.05)',
+                    minWidth: 420,
+                  }}
+                >
+                  <div style={{ fontSize: 22, color: '#64748b', display: 'flex' }}>連休プラン</div>
+                  <div
+                    style={{
+                      fontSize: 76,
+                      fontWeight: 800,
+                      color: '#1d4ed8',
+                      lineHeight: 1.1,
+                      display: 'flex',
+                    }}
+                  >
+                    {plan.totalDaysOff}連休
+                  </div>
+                  <div style={{ fontSize: 22, color: '#0369a1', display: 'flex' }}>{ptoLabel}</div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div
+              style={{
+                fontSize: 64,
+                fontWeight: 800,
+                color: '#0f172a',
+                display: 'flex',
+              }}
+            >
+              次の祝日カウントダウン
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ fontSize: 22, color: '#475569', display: 'flex' }}>
+            有給を活かして最長の連休を計画
+          </div>
+          <div style={{ fontSize: 22, color: '#475569', display: 'flex' }}>
+            madeforx.com/holidays
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/components/Holidays/ShareButton.tsx
+++ b/src/components/Holidays/ShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface ShareButtonProps {
   title: string;
@@ -11,38 +11,69 @@ interface ShareButtonProps {
 export default function ShareButton({ title, text, url }: ShareButtonProps) {
   const [feedback, setFeedback] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
 
   const showFeedback = (message: string) => {
     setFeedback(message);
     setTimeout(() => setFeedback(null), 2000);
   };
 
-  const handleNativeShare = async () => {
-    if (typeof navigator !== 'undefined' && 'share' in navigator) {
-      try {
-        await navigator.share({ title, text, url });
-        return true;
-      } catch (err) {
-        if ((err as Error)?.name === 'AbortError') return true;
-      }
+  const handleNativeShare = async (): Promise<boolean> => {
+    if (typeof navigator === 'undefined' || !('share' in navigator)) return false;
+    try {
+      await navigator.share({ title, text, url });
+      return true;
+    } catch (err) {
+      const name = (err as Error)?.name;
+      if (name === 'AbortError') return true;
+      return false;
     }
-    return false;
   };
 
   const handleCopyLink = async () => {
+    setMenuOpen(false);
     try {
       await navigator.clipboard.writeText(url);
       showFeedback('リンクをコピーしました');
     } catch {
       showFeedback('コピーに失敗しました');
     }
-    setMenuOpen(false);
   };
 
   const handleClick = async () => {
+    if (menuOpen) {
+      setMenuOpen(false);
+      return;
+    }
     const handled = await handleNativeShare();
     if (!handled) {
-      setMenuOpen((open) => !open);
+      setMenuOpen(true);
     }
   };
 
@@ -55,12 +86,14 @@ export default function ShareButton({ title, text, url }: ShareButtonProps) {
   const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 
   return (
-    <div className="relative">
+    <div className="relative" ref={containerRef}>
       <button
+        ref={buttonRef}
         type="button"
         onClick={handleClick}
         className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium shadow-sm"
         aria-label="このページをシェアする"
+        aria-haspopup="menu"
         aria-expanded={menuOpen}
       >
         <svg
@@ -84,7 +117,8 @@ export default function ShareButton({ title, text, url }: ShareButtonProps) {
       {feedback && (
         <div
           role="status"
-          className="absolute right-0 mt-2 px-3 py-1 bg-gray-900 text-white text-xs rounded-md shadow-md whitespace-nowrap"
+          aria-live="polite"
+          className="absolute right-0 top-full mt-2 px-3 py-1 bg-gray-900 text-white text-xs rounded-md shadow-md whitespace-nowrap z-50"
         >
           {feedback}
         </div>
@@ -92,7 +126,7 @@ export default function ShareButton({ title, text, url }: ShareButtonProps) {
 
       {menuOpen && !feedback && (
         <div
-          className="absolute right-0 mt-2 w-44 bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden z-10"
+          className="absolute right-0 top-full mt-2 w-44 bg-white border border-gray-200 rounded-lg shadow-xl overflow-hidden z-50"
           role="menu"
         >
           <button

--- a/src/components/Holidays/ShareButton.tsx
+++ b/src/components/Holidays/ShareButton.tsx
@@ -44,18 +44,6 @@ export default function ShareButton({ title, text, url }: ShareButtonProps) {
     setTimeout(() => setFeedback(null), 2000);
   };
 
-  const handleNativeShare = async (): Promise<boolean> => {
-    if (typeof navigator === 'undefined' || !('share' in navigator)) return false;
-    try {
-      await navigator.share({ title, text, url });
-      return true;
-    } catch (err) {
-      const name = (err as Error)?.name;
-      if (name === 'AbortError') return true;
-      return false;
-    }
-  };
-
   const handleCopyLink = async () => {
     setMenuOpen(false);
     try {
@@ -66,15 +54,8 @@ export default function ShareButton({ title, text, url }: ShareButtonProps) {
     }
   };
 
-  const handleClick = async () => {
-    if (menuOpen) {
-      setMenuOpen(false);
-      return;
-    }
-    const handled = await handleNativeShare();
-    if (!handled) {
-      setMenuOpen(true);
-    }
+  const handleClick = () => {
+    setMenuOpen((open) => !open);
   };
 
   const encodedText = encodeURIComponent(`${text} ${url}`);


### PR DESCRIPTION
Follow-up to #39 fixing the share button on `/holidays`.

## What was broken

- **Copy paste was producing URL+text**: On desktop Chrome `navigator.share` is available, so clicking the share button hijacked into Chrome's native share UI. Chrome's **Copy** option there concatenates `title + text + url`, so users got `https://madeforx.com/holidays次の祝日「海の日」(...)…` pasted instead of just the URL.
- **Menu didn't dismiss properly**: clicks outside the menu and the Escape key did nothing; re-clicking the trigger could race with the native-share path.
- **X share was a plain link, no card image**: only OG title/description were set, so tweets unfurled into a bare text preview.

## Fixes

- Drop the Web Share API path. The share button always opens the in-page dropdown (Copy link / X / LINE / Facebook), so **Copy link** only ever writes the URL to the clipboard.
- Add `pointerdown` listener while menu is open → clicks outside the share container close it.
- Add `keydown` Escape listener → closes menu and returns focus to the trigger.
- Re-clicking the share button now reliably toggles closed.
- Add `src/app/holidays/opengraph-image.tsx`: edge-runtime `ImageResponse` that renders a 1200×630 PNG with the next holiday name, date, `あと N 日` countdown, and 連休 plan. Next.js auto-wires it to `og:image` and `twitter:image`. Combined with the existing `twitter:card=summary_large_image`, links to `/holidays` now unfurl on X as a rich card showing the actual upcoming holiday.

## Test plan

- [x] `npm run build` clean (`ƒ /holidays/opengraph-image` route registered)
- [x] Chrome E2E:
  - [x] Click share → dropdown opens (no Chrome native dialog)
  - [x] Click outside → menu closes
  - [x] Escape → menu closes
  - [x] Re-click trigger → menu closes
  - [x] Copy link writes only the page URL
  - [x] `GET /holidays/opengraph-image` returns a PNG showing 海の日 / 2026年7月20日 / 66日 / 3連休
  - [x] `/holidays` head contains `og:image` and `twitter:image` pointing at `/holidays/opengraph-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)