### PR TITLE
fix(og-image): cache the holidays OG image so X can use it

### DIFF
--- a/src/app/holidays/opengraph-image.tsx
+++ b/src/app/holidays/opengraph-image.tsx
@@ -5,6 +5,7 @@ import holiday_jp from '@holiday-jp/holiday_jp';
 import { Holiday } from '@/lib/holidays/types';
 
 export const runtime = 'edge';
+export const revalidate = 3600;
 
 export const alt = '次の祝日カウントダウン・連休プランナー';
 export const size = { width: 1200, height: 630 };
@@ -228,6 +229,9 @@ export default async function OpenGraphImage() {
     ),
     {
       ...size,
+      headers: {
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      },
     }
   );
 }


### PR DESCRIPTION
Follow-up to #40.

## Why X showed a placeholder instead of the image

The OG image route was returning \`Cache-Control: max-age=0, must-revalidate\` and Vercel logs showed \`x-vercel-cache: MISS\` on every request — so every Twitterbot/X fetch triggered a ~1.1s edge cold render with no caching anywhere. X likely gave up waiting on the first try and stored a "no image" result, which is why the actual tweet rendered as a small summary card with the document-icon placeholder even though the third-party Twitter Card Validator shows the image fine (the validator fetches once on demand; X's tweet renderer relies on its own cache).

## Fix

- \`export const revalidate = 3600\` on the OG image route → Vercel serves a cached PNG between regenerations.
- Add \`Cache-Control: public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400\` in the \`ImageResponse\` so downstream crawlers (X, FB, LINE, Slack, Discord) can cache for an hour and use a stale copy while we regenerate.

Image content still updates within the hour as the next holiday's countdown progresses.

## After deploy

Once this is live, paste \`https://madeforx.com/holidays\` into [cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator) once to refresh X's per-URL cache. Already-posted tweets won't update — only new shares pick up the refreshed card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)