### PR TITLE
chore(gitignore): ignore .gstack and articles directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ CLAUDE.md
 # Superpowers brainstorming
 .superpowers/
 /docs/superpowers/
+/.gstack
+/articles


### PR DESCRIPTION
## Summary
- Add `/.gstack` and `/articles` to `.gitignore` so local tooling artifacts and draft articles stay out of the repo.

## Test plan
- [x] `git status` clean after ignoring the directories locally