### PR TITLE
fix(test): repair 3 long-broken shipping suites + stop jest hitting prod DB

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# Jest database — always the LOCAL dev database, never production.
+# jest.env.js loads this before .env, so tests stop falling back to the
+# production DATABASE_URL. Per-machine override: .env.test.local (gitignored).
+DATABASE_URL="postgresql://ryan@localhost:5432/madeforx_dev"

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,8 @@ next-env.d.ts
 # Generated files
 README-development.md
 /scripts/setup-env.sh
-/.env.test
+# .env.test is tracked on purpose: it pins jest to the LOCAL database
+# (no secrets — localhost URL only). Machine overrides: .env.test.local
 
 # Serena AI assistant files
 .serena/

--- a/src/app/api/shipping/feedback/__tests__/route.test.ts
+++ b/src/app/api/shipping/feedback/__tests__/route.test.ts
@@ -6,17 +6,23 @@ import { NextRequest } from 'next/server';
 import { POST, GET } from '../route';
 import { PrismaClient } from '@prisma/client';
 
-// Mock Prisma
-jest.mock('@prisma/client', () => ({
-  PrismaClient: jest.fn().mockImplementation(() => ({
-    shippingFeedback: {
-      create: jest.fn(),
-      findMany: jest.fn(),
-      count: jest.fn(),
-    },
-    $disconnect: jest.fn(),
-  })),
-}));
+// Mock Prisma. Every PrismaClient instance must share the SAME model object:
+// the route module creates its own client at import time, so a factory that
+// builds a fresh object per instance would leave the route's client with
+// mocks this test never configured (create → undefined → 500).
+jest.mock('@prisma/client', () => {
+  const mockShippingFeedback = {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  };
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      shippingFeedback: mockShippingFeedback,
+      $disconnect: jest.fn(),
+    })),
+  };
+});
 
 const mockPrisma = new PrismaClient() as jest.Mocked<PrismaClient>;
 
@@ -192,7 +198,10 @@ describe('/api/shipping/feedback', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.feedbacks).toEqual(mockFeedbacks);
+      // Dates come back JSON-serialized as ISO strings
+      expect(data.feedbacks).toEqual(
+        mockFeedbacks.map((f) => ({ ...f, createdAt: f.createdAt.toISOString() }))
+      );
       expect(data.total).toBe(2);
       expect(data.limit).toBe(50);
       expect(data.offset).toBe(0);

--- a/src/components/ShippingCalculator/__tests__/FeedbackModal.test.tsx
+++ b/src/components/ShippingCalculator/__tests__/FeedbackModal.test.tsx
@@ -75,11 +75,15 @@ describe('FeedbackModal', () => {
     expect(submitButton).toBeEnabled();
   });
 
-  it('enables submit button when custom feedback is provided', () => {
+  it('reveals the custom feedback textarea via その他 and enables submit', () => {
     render(<FeedbackModal {...mockProps} />);
 
     const submitButton = screen.getByRole('button', { name: /送信/ });
     expect(submitButton).toBeDisabled();
+    // The textarea only renders once その他 is selected
+    expect(screen.queryByPlaceholderText(/具体的な問題や改善要望/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('その他'));
 
     const textarea = screen.getByPlaceholderText(/具体的な問題や改善要望/);
     fireEvent.change(textarea, { target: { value: 'Test feedback' } });

--- a/src/lib/shipping/__tests__/complete-seed-validation.test.ts
+++ b/src/lib/shipping/__tests__/complete-seed-validation.test.ts
@@ -46,7 +46,8 @@ describe('Complete Seed Data Validation Tests', () => {
     });
 
     test('should find 宅急便コンパクト (薄型BOX) with 内寸 dimensions', async () => {
-      const dimensions: ShippingDimensions = { length: 24, width: 33, height: 1 };
+      // 薄型BOX 内寸厚 is 0.9cm (seed maxHeightCm); height 1 would be excluded
+      const dimensions: ShippingDimensions = { length: 24, width: 33, height: 0.9 };
       const fixedOptions = await getFixedPriceOptions(dimensions, prisma);
 
       const compactThin = fixedOptions.find(
@@ -244,8 +245,8 @@ describe('Complete Seed Data Validation Tests', () => {
     });
 
     test('should distinguish between 宅急便コンパクト BOX types based on dimensions', async () => {
-      // Item that fits thin BOX but not regular BOX
-      const thinBoxItem: ShippingDimensions = { length: 24, width: 33, height: 1 };
+      // Item that fits thin BOX (内寸厚 0.9cm) but not regular BOX
+      const thinBoxItem: ShippingDimensions = { length: 24, width: 33, height: 0.9 };
       const thinOptions = await getFixedPriceOptions(thinBoxItem, prisma);
 
       const thinBox = thinOptions.find((opt) => opt.optionName === '宅急便コンパクト (薄型BOX)');


### PR DESCRIPTION
## 概要
約1年前から失敗し続けていた shipping 系3スイート（26テスト）を修理し、テストが本番DBに接続していた問題を解消します。**フルスイート初の 168/168 グリーン**（従来 142/168、実行時間 55s→1.4s）。

## 根本原因と修正
| スイート | 原因 | 修正 |
|---|---|---|
| `api/shipping/feedback` route.test (6件) | PrismaClient モックがインスタンスごとに別オブジェクトを返し、route 側クライアントにモックが刺さらない → create が undefined → 500 | ファクトリ内で単一のモデルオブジェクトを共有。加えて GET 期待値の Date→ISO文字列（JSON化）を修正 |
| FeedbackModal.test (1件) | textarea は「その他」選択時のみ描画される仕様に変わったが、テストは無条件に取得 | 先に「その他」をクリック。非表示→表示の遷移も検証 |
| complete-seed-validation (2件) | 薄型BOX の seed `maxHeightCm=0.9` に対しテストが `height:1` で検索 → fit フィルタで除外 | 0.9（内寸厚の境界値）で検索 |

## テストが本番DBを叩いていた問題
`jest.env.js` は `.env.test` → `.env` の順でフォールバックし、`.env.test` が存在しなかったため**テストスイート全体が本番 Neon に接続**していました。秘密情報を含まない `.env.test`（localhost URL のみ）を追加し、`.gitignore` の `/.env.test` を解除（マシン別の上書きは gitignored の `.env.test.local` で）。

テスト専用の変更のみで、ランタイムコードには触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)