### PR TITLE
feat(seo): server-rendered JSON-LD, visible FAQs, llms.txt, AI crawler rules, default OG image

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,22 @@
+# Made for X
+
+> 日本の生活とビジネスを支える無料Webツール集。AIメール作成、メルカリ配送料計算、千葉県ごみ収集スケジュール検索、日本郵便輸出インボイス作成、休憩タイマー、祝日カウントダウンを提供。全ツール無料・会員登録不要。
+> Made for X is a collection of free web tools for life and business in Japan: AI business email writer, Mercari shipping cost calculator, Chiba Prefecture garbage collection schedule search, Japan Post export invoice generator, break timer, and Japanese holiday countdown. All tools are free and require no sign-up.
+
+サイトの言語は日本語です。運営: Made for X (https://madeforx.com)
+
+## ツール (Tools)
+
+- [AIメール作成ツール](https://madeforx.com/mail-generator): 要件を入力するだけでAIが丁寧な日本語ビジネスメールを自動生成。会議依頼・お礼・お詫び・問い合わせなどに対応。日本語・英語・簡体字中国語・繁体字中国語の4言語対応。
+- [AI返信メール作成](https://madeforx.com/mail-generator/reply): 受信したメールを貼り付けると、内容を分析して適切な返信文章をAIが自動作成。
+- [AIチャット形式メール作成](https://madeforx.com/mail-generator/chat): チャットで対話しながらビジネスメールを作成。複雑な要件も会話形式で伝えられる。
+- [メルカリ配送料金計算器](https://madeforx.com/shipping-calculator): 商品の縦・横・厚さ・重量を入力すると、らくらくメルカリ便（ネコポス・宅急便コンパクト・宅急便）とゆうゆうメルカリ便（ゆうパケット・ゆうパケットポスト・ゆうパケットプラス・ゆうパック）の全配送方法の料金を比較し、最安の配送方法を判定。
+- [千葉県ごみ収集スケジュール検索](https://madeforx.com/waste-collection): 千葉県全60市町村のごみ収集日を住所・町名・郵便番号から検索。燃やすごみ・燃やさないごみ・資源ごみなどの収集曜日を確認できる。
+- [日本郵便 輸出インボイス自動作成](https://madeforx.com/japanpost): EMS・国際eパケットなど日本郵便の国際郵便向け輸出インボイスをAIで自動作成。商品名からHSコード（関税分類番号）を自動判定。
+- [次の祝日カウントダウン・連休プランナー](https://madeforx.com/holidays): 日本の次の祝日までの日数をリアルタイム表示。有給休暇を使った橋渡し（ブリッジ）連休プランを自動計算。
+- [休憩タイマー](https://madeforx.com/break): 短時間休憩（5分）と長時間休憩（15分）に対応したシンプルなタイマー。ポモドーロテクニックの休憩に最適。
+
+## その他 (Other)
+
+- [プライバシーポリシー](https://madeforx.com/mail-generator/privacy): AIメール作成ツールのプライバシーポリシー。入力内容はサーバーに保存されません。
+- [サイトマップ](https://madeforx.com/sitemap.xml)

--- a/src/app/break/page.tsx
+++ b/src/app/break/page.tsx
@@ -4,6 +4,7 @@ import {
   BreadcrumbStructuredData,
   FAQStructuredData,
 } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: '休憩タイマー - 集中と休憩の最適バランス',
@@ -87,6 +88,7 @@ export default function BreakPage() {
       />
       <FAQStructuredData items={FAQ_ITEMS} id="break-faq" />
       <BreakTimer />
+      <FAQSection items={FAQ_ITEMS} />
     </>
   );
 }

--- a/src/app/holidays/page.tsx
+++ b/src/app/holidays/page.tsx
@@ -5,6 +5,7 @@ import {
   BreadcrumbStructuredData,
   FAQStructuredData,
 } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: '次の祝日カウントダウン・連休プランナー',
@@ -97,6 +98,7 @@ export default function HolidaysPage() {
       />
       <FAQStructuredData items={FAQ_ITEMS} id="holidays-faq" />
       <HolidayCard />
+      <FAQSection items={FAQ_ITEMS} />
     </>
   );
 }

--- a/src/app/japanpost/page.tsx
+++ b/src/app/japanpost/page.tsx
@@ -4,6 +4,7 @@ import {
   BreadcrumbStructuredData,
   FAQStructuredData,
 } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: '日本郵便 輸出インボイス自動作成ツール - HSコード自動生成',
@@ -96,6 +97,7 @@ export default function Home() {
       <FAQStructuredData items={FAQ_ITEMS} id="japanpost-faq" />
       <div className="bg-gray-50">
         <ExportInvoiceForm />
+        <FAQSection items={FAQ_ITEMS} />
       </div>
     </>
   );

--- a/src/app/mail-generator/chat/page.tsx
+++ b/src/app/mail-generator/chat/page.tsx
@@ -18,6 +18,13 @@ export const metadata = {
     'インタラクティブ',
     'AI対話',
   ],
+  alternates: {
+    canonical: '/mail-generator/chat',
+    languages: {
+      'ja-JP': '/mail-generator/chat',
+      'x-default': '/mail-generator/chat',
+    },
+  },
   openGraph: {
     title: 'AIチャット形式メール作成 - 対話型ビジネスメール生成',
     description:

--- a/src/app/mail-generator/page.tsx
+++ b/src/app/mail-generator/page.tsx
@@ -7,6 +7,7 @@ import {
   BreadcrumbStructuredData,
   FAQStructuredData,
 } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: 'AIメール作成ツール - ビジネス日本語メール自動生成',
@@ -136,6 +137,7 @@ export default function MailGeneratorPage() {
           <MailGeneratorForm />
         </div>
       </div>
+      <FAQSection items={FAQ_ITEMS} />
     </>
   );
 }

--- a/src/app/mail-generator/privacy/page.tsx
+++ b/src/app/mail-generator/privacy/page.tsx
@@ -5,6 +5,26 @@ import {
   shouldShowNewTag,
 } from '@/utils/feature-notifications';
 
+export const metadata = {
+  title: 'プライバシーポリシー - AIメール作成ツール',
+  description:
+    'Made for X AIメール作成ツールのプライバシーポリシー。入力されたメール内容の取り扱い、データの保存方針、外部サービスの利用について説明します。',
+  alternates: {
+    canonical: '/mail-generator/privacy',
+    languages: {
+      'ja-JP': '/mail-generator/privacy',
+      'x-default': '/mail-generator/privacy',
+    },
+  },
+  openGraph: {
+    title: 'プライバシーポリシー - AIメール作成ツール | Made for X',
+    description:
+      'Made for X AIメール作成ツールのプライバシーポリシー。入力されたメール内容の取り扱い、データの保存方針について説明します。',
+    type: 'website',
+    url: 'https://madeforx.com/mail-generator/privacy',
+  },
+};
+
 export default function PrivacyPolicyPage() {
   const showUpdateNotification = shouldShowUpdateNotification();
   const formattedUpdateDate = getFormattedUpdateDate();

--- a/src/app/mail-generator/reply/page.tsx
+++ b/src/app/mail-generator/reply/page.tsx
@@ -18,6 +18,13 @@ export const metadata = {
     '返信文章',
     '返信作成',
   ],
+  alternates: {
+    canonical: '/mail-generator/reply',
+    languages: {
+      'ja-JP': '/mail-generator/reply',
+      'x-default': '/mail-generator/reply',
+    },
+  },
   openGraph: {
     title: 'AI返信メール作成 - 自動返信文章生成ツール',
     description:

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,27 @@
+import { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Made for X - 日本の生活とビジネスを支える無料ツール集',
+    short_name: 'Made for X',
+    description:
+      'AIメール作成、メルカリ配送料計算、千葉県ごみ収集スケジュール、日本郵便輸出インボイス、休憩タイマー、祝日カウントダウン。日本での生活と仕事を効率化する無料ツールを提供します。',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#f9fafb',
+    theme_color: '#2563eb',
+    lang: 'ja',
+    icons: [
+      {
+        src: '/favicon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+      },
+      {
+        src: '/favicon-32x32.png',
+        sizes: '32x32',
+        type: 'image/png',
+      },
+    ],
+  };
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,124 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const revalidate = 86400;
+
+export const alt = 'Made for X - 日本の生活とビジネスを支える無料ツール集';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const TOOLS = [
+  'AIメール作成',
+  'メルカリ配送料計算',
+  '千葉県ごみ収集',
+  '輸出インボイス',
+  '祝日カウントダウン',
+  '休憩タイマー',
+];
+
+export default async function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          backgroundImage: 'linear-gradient(135deg, #e0f2fe 0%, #dbeafe 100%)',
+          padding: '60px 80px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+          <div
+            style={{
+              width: 88,
+              height: 88,
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 6,
+            }}
+          >
+            {[
+              '#60a5fa',
+              '#34d399',
+              '#f87171',
+              '#fb923c',
+              '#a78bfa',
+              '#22d3ee',
+              '#fbbf24',
+              '#e5e7eb',
+              '#10b981',
+            ].map((color) => (
+              <div
+                key={color}
+                style={{
+                  width: 25,
+                  height: 25,
+                  borderRadius: 6,
+                  backgroundColor: color,
+                  display: 'flex',
+                }}
+              />
+            ))}
+          </div>
+          <div style={{ fontSize: 72, color: '#1f2937', fontWeight: 700, display: 'flex' }}>
+            Made for X
+          </div>
+        </div>
+
+        <div
+          style={{
+            fontSize: 36,
+            color: '#475569',
+            marginTop: 32,
+            display: 'flex',
+          }}
+        >
+          日本の生活とビジネスを支える無料ツール集
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            gap: 12,
+            marginTop: 40,
+            maxWidth: 900,
+          }}
+        >
+          {TOOLS.map((tool) => (
+            <div
+              key={tool}
+              style={{
+                display: 'flex',
+                fontSize: 24,
+                color: '#1e40af',
+                backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                borderRadius: 9999,
+                padding: '10px 24px',
+              }}
+            >
+              {tool}
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            fontSize: 24,
+            color: '#64748b',
+            marginTop: 44,
+            display: 'flex',
+          }}
+        >
+          madeforx.com ・ 無料・登録不要
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import HomePage from '@/components/Home/HomePage';
 import { FAQStructuredData } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: 'Made for X - 日本の生活とビジネスを支える無料ツール集',
@@ -70,6 +71,7 @@ export default function Home() {
     <>
       <FAQStructuredData items={FAQ_ITEMS} id="home-faq" />
       <HomePage />
+      <FAQSection items={FAQ_ITEMS} />
     </>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,10 +1,36 @@
 import { MetadataRoute } from 'next';
 
+// AI/LLM crawlers we explicitly welcome (GEO: Generative Engine Optimization).
+// They are already covered by the "*" rule, but explicit rules remove any
+// ambiguity and document the intent to be indexable by AI search engines.
+const AI_CRAWLERS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-User',
+  'Claude-SearchBot',
+  'anthropic-ai',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Google-Extended',
+  'Applebot-Extended',
+  'CCBot',
+  'meta-externalagent',
+  'Amazonbot',
+  'DuckAssistBot',
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: '*',
+        allow: '/',
+        disallow: ['/api/'],
+      },
+      {
+        userAgent: AI_CRAWLERS,
         allow: '/',
         disallow: ['/api/'],
       },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -59,5 +59,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/mail-generator/privacy`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
   ];
 }

--- a/src/app/waste-collection/page.tsx
+++ b/src/app/waste-collection/page.tsx
@@ -4,6 +4,7 @@ import {
   BreadcrumbStructuredData,
   FAQStructuredData,
 } from '@/components/StructuredData';
+import FAQSection from '@/components/FAQSection';
 
 export const metadata = {
   title: '千葉県ごみ収集スケジュール検索 - 市町村・住所別収集日確認',
@@ -90,6 +91,7 @@ export default function WasteCollectionPage() {
       <FAQStructuredData items={FAQ_ITEMS} id="waste-collection-faq" />
       <div className="flex flex-col bg-gray-50">
         <WasteCollectionForm />
+        <FAQSection items={FAQ_ITEMS} />
       </div>
     </>
   );

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,0 +1,31 @@
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface FAQSectionProps {
+  items: FAQItem[];
+}
+
+// Visible FAQ that mirrors FAQStructuredData: Google requires FAQ structured data
+// to reflect content that is actually on the page, and AI search engines can only
+// cite content present in the rendered HTML.
+export default function FAQSection({ items }: FAQSectionProps) {
+  return (
+    <section aria-labelledby="faq-heading" className="container mx-auto px-4 py-8">
+      <div className="max-w-4xl mx-auto bg-white rounded-lg shadow-md p-6">
+        <h2 id="faq-heading" className="text-xl font-semibold text-gray-900 mb-4">
+          よくある質問
+        </h2>
+        <div className="space-y-4">
+          {items.map((item) => (
+            <div key={item.question}>
+              <h3 className="font-medium text-gray-800 mb-2">Q. {item.question}</h3>
+              <p className="text-gray-600 text-sm leading-relaxed">{item.answer}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,4 +1,16 @@
-import Script from 'next/script';
+// JSON-LD is rendered as an inline <script> in the server HTML (not via next/script)
+// so that crawlers that don't execute JavaScript — including most AI crawlers like
+// GPTBot, ClaudeBot, and PerplexityBot — can read the structured data.
+function JsonLd({ id, data }: { id: string; data: Record<string, unknown> }) {
+  return (
+    <script
+      id={id}
+      type="application/ld+json"
+      // Escape "<" to prevent the payload from closing the script tag early.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, '\\u003c') }}
+    />
+  );
+}
 
 interface ServiceStructuredDataProps {
   name: string;
@@ -35,6 +47,8 @@ export function ServiceStructuredData({
     name,
     description,
     url,
+    inLanguage: 'ja',
+    isAccessibleForFree: true,
     applicationCategory,
     operatingSystem,
     ...(offers && { offers: { '@type': 'Offer', ...offers } }),
@@ -47,12 +61,9 @@ export function ServiceStructuredData({
   };
 
   return (
-    <Script
+    <JsonLd
       id={`structured-data-${name.replace(/\s+/g, '-').toLowerCase()}`}
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
+      data={structuredData}
     />
   );
 }
@@ -76,15 +87,7 @@ export function BreadcrumbStructuredData({ items }: BreadcrumbStructuredDataProp
     })),
   };
 
-  return (
-    <Script
-      id="breadcrumb-structured-data"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
-    />
-  );
+  return <JsonLd id="breadcrumb-structured-data" data={structuredData} />;
 }
 
 interface OrganizationStructuredDataProps {
@@ -112,15 +115,7 @@ export function OrganizationStructuredData({
     ...(sameAs && { sameAs }),
   };
 
-  return (
-    <Script
-      id="organization-structured-data"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
-    />
-  );
+  return <JsonLd id="organization-structured-data" data={structuredData} />;
 }
 
 interface FAQItem {
@@ -137,6 +132,7 @@ export function FAQStructuredData({ items, id = 'faq-structured-data' }: FAQStru
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
+    inLanguage: 'ja',
     mainEntity: items.map((item) => ({
       '@type': 'Question',
       name: item.question,
@@ -147,15 +143,7 @@ export function FAQStructuredData({ items, id = 'faq-structured-data' }: FAQStru
     })),
   };
 
-  return (
-    <Script
-      id={id}
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
-    />
-  );
+  return <JsonLd id={id} data={structuredData} />;
 }
 
 interface WebSiteStructuredDataProps {
@@ -191,13 +179,5 @@ export function WebSiteStructuredData({
     }),
   };
 
-  return (
-    <Script
-      id="website-structured-data"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
-    />
-  );
+  return <JsonLd id="website-structured-data" data={structuredData} />;
 }


### PR DESCRIPTION
SEO/GEO improvements:
- Render JSON-LD structured data as inline server-side <script> tags instead
  of next/script, so crawlers that don't execute JavaScript (GPTBot, ClaudeBot,
  PerplexityBot, etc.) can read it; escape "<" in the JSON payload
- Add visible FAQ sections (FAQSection component) to pages that previously had
  FAQ markup only in structured data, per Google's requirement that FAQ
  structured data reflect on-page content
- Add public/llms.txt describing the site and each tool for AI engines
- Add explicit robots.txt rules welcoming major AI crawlers
- Add site-wide default Open Graph image (app/opengraph-image.tsx); cards
  previously declared summary_large_image with no image on most pages
- Add web app manifest (app/manifest.ts)
- Add missing canonical/hreflang to /mail-generator/reply and /chat
- Add metadata to /mail-generator/privacy and include it in the sitemap
- Add inLanguage and isAccessibleForFree to WebApplication/FAQ structured data

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BQhLcxU88f9JyHEadAm2S4