### PR TITLE
korea-visa: header nav link + Noto Sans JP fallback for shinjitai mojibake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@expo-google-fonts/noto-sans-jp": "^0.4.3",
         "@expo-google-fonts/noto-sans-kr": "^0.4.3",
         "@holiday-jp/holiday_jp": "^2.5.1",
         "@prisma/client": "^6.8.2",
@@ -1191,6 +1192,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/noto-sans-jp": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/noto-sans-jp/-/noto-sans-jp-0.4.3.tgz",
+      "integrity": "sha512-Fl+Z6vtD24HFAYsvzB0S9Nery1ly16B9PesdY0wBd+wEHAvkNglnkTUspU0HqGOubkmoa8zusJrKv6vDx1o70A==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/noto-sans-kr": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     ]
   },
   "dependencies": {
+    "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@expo-google-fonts/noto-sans-kr": "^0.4.3",
     "@holiday-jp/holiday_jp": "^2.5.1",
     "@prisma/client": "^6.8.2",

--- a/scripts/copy-assets.mts
+++ b/scripts/copy-assets.mts
@@ -1,8 +1,9 @@
 /**
  * Postinstall: copy runtime assets that must be served from /public.
  * - pdfjs worker (same pinned version as the API, so worker/API never mismatch)
- * - Noto Sans KR TTF (embedded into filled PDFs; ships via npm so every
- *   environment gets identical bytes)
+ * - Noto Sans KR + JP TTFs (embedded into filled PDFs — KR primary, JP
+ *   fallback for shinjitai; ship via npm so every environment gets
+ *   identical bytes)
  * Fails loudly if a source file is missing.
  */
 import { copyFileSync, mkdirSync, existsSync } from 'node:fs';
@@ -19,6 +20,10 @@ const assets: Array<[src: string, dest: string]> = [
   [
     join(root, 'node_modules/@expo-google-fonts/noto-sans-kr/400Regular/NotoSansKR_400Regular.ttf'),
     join(root, 'public/fonts/NotoSansKR-Regular.ttf'),
+  ],
+  [
+    join(root, 'node_modules/@expo-google-fonts/noto-sans-jp/400Regular/NotoSansJP_400Regular.ttf'),
+    join(root, 'public/fonts/NotoSansJP-Regular.ttf'),
   ],
 ];
 

--- a/scripts/verify-korea-visa-fill.mts
+++ b/scripts/verify-korea-visa-fill.mts
@@ -3,7 +3,9 @@
  * golden sample data, then re-extract text with pdf.js and assert
  * (1) the document keeps its shape, (2) no overflow warnings,
  * (3) every text value actually landed in the PDF, (4) checkbox marks are
- * real check marks (U+2713), which the blank form contains zero of.
+ * real check marks (U+2713), which the blank form contains zero of,
+ * (5) Japanese shinjitai (戸込渋 — absent from Noto Sans KR) land via the
+ * Noto Sans JP fallback instead of drawing as tofu.
  * Also writes out/korea-visa-golden.pdf for a human visual pass.
  * Source of truth for stricter placement assertions:
  * /Users/ryan/WebstormProjects/PdfToFormToPdf/tests/unit/fill.roundtrip.test.ts
@@ -23,9 +25,19 @@ const check = (ok: boolean, label: string) => {
 };
 
 const original = new Uint8Array(readFileSync(join(root, 'public/samples/visa-application.pdf')));
-const fontBytes = new Uint8Array(readFileSync(join(root, 'public/fonts/NotoSansKR-Regular.ttf')));
+const fontBytes = {
+  primary: new Uint8Array(readFileSync(join(root, 'public/fonts/NotoSansKR-Regular.ttf'))),
+  fallbacks: [new Uint8Array(readFileSync(join(root, 'public/fonts/NotoSansJP-Regular.ttf')))],
+};
 
 const values = goldenValues(SAMPLE_TEMPLATE);
+// Shinjitai probe: 江 exists in Noto Sans KR, 戸込渋 only in Noto Sans JP —
+// a mixed KR/JP run through the first free-text field.
+const JP_PROBE = '江戸込渋';
+const probeField = SAMPLE_TEMPLATE.fields.find((f) => f.type === 'text' && !f.validation);
+if (!probeField) throw new Error('no free-text field for the shinjitai probe');
+values[probeField.id] = JP_PROBE;
+
 const { bytes: filled, warnings } = await fillPdf(original, SAMPLE_TEMPLATE, values, fontBytes);
 check(
   warnings.length === 0,
@@ -62,6 +74,9 @@ check(missing.length === 0, `every text value landed (missing: ${missing.join(',
 const countChecks = (t: string) => (t.match(/✓/g) ?? []).length;
 check(countChecks(before.text) === 0, 'blank form has no U+2713');
 check(countChecks(after.text) > 0, `filled form has real check marks (${countChecks(after.text)})`);
+
+check(!before.text.includes('戸'), 'blank form has no shinjitai');
+check(after.text.includes(JP_PROBE), `shinjitai landed via JP fallback (${JP_PROBE})`);
 
 mkdirSync(join(root, 'out'), { recursive: true });
 writeFileSync(join(root, 'out/korea-visa-golden.pdf'), filled);

--- a/src/components/KoreaVisa/__tests__/useFilledPdf.stale.test.tsx
+++ b/src/components/KoreaVisa/__tests__/useFilledPdf.stale.test.tsx
@@ -10,7 +10,9 @@ jest.mock('@/lib/korea-visa/fill/fillPdf', () => ({
   fillPdf: jest.fn().mockImplementation(async () => ({ bytes: new Uint8Array([1]), warnings: [] })),
 }));
 jest.mock('@/lib/korea-visa/fill/fonts', () => ({
-  loadFontBytes: jest.fn().mockImplementation(async () => new Uint8Array([9])),
+  loadFontBytes: jest
+    .fn()
+    .mockImplementation(async () => ({ primary: new Uint8Array([9]), fallbacks: [] })),
 }));
 
 const pdfBytes = new Uint8Array([0]);

--- a/src/lib/korea-visa/fill/fillPdf.ts
+++ b/src/lib/korea-visa/fill/fillPdf.ts
@@ -11,6 +11,8 @@ import type { Rect } from '../pdf/coords';
 import type { DateValue, Field, FormTemplate, FormValues } from '../template/schema';
 import { formatDateValue } from '../template/schema';
 import { isFieldVisible } from '../form/visibility';
+import type { FillFontBytes } from './fonts';
+import { FontSet, coverageFor } from './fontSet';
 import { centeredBaseline, fitSize, layoutMultiline } from './layout';
 
 export interface FillResult {
@@ -25,14 +27,18 @@ export async function fillPdf(
   originalBytes: Uint8Array,
   template: FormTemplate,
   values: FormValues,
-  fontBytes: Uint8Array
+  fontBytes: FillFontBytes
 ): Promise<FillResult> {
   const warnings: string[] = [];
   const doc = await PDFDocument.load(originalBytes, { updateMetadata: false });
   // fontkit 2 via shim: the @pdf-lib/fontkit fork corrupts Noto Sans KR
   // subset outlines (text extracts but doesn't render) — see fontkit2Shim.
   doc.registerFontkit(fontkitForPdfLib as never);
-  const font = await doc.embedFont(fontBytes, { subset: true });
+  const allFontBytes = [fontBytes.primary, ...fontBytes.fallbacks];
+  const embedded = await Promise.all(allFontBytes.map((b) => doc.embedFont(b, { subset: true })));
+  const font = new FontSet(
+    embedded.map((f, i) => ({ font: f, coverage: coverageFor(allFontBytes[i]) }))
+  );
 
   const pages = doc.getPages();
   if (pages.length !== template.pdf.pageCount) {
@@ -45,14 +51,14 @@ export async function fillPdf(
     }
   });
 
-  const canDrawCheckGlyph = (() => {
-    try {
-      font.encodeText(CHECK_MARK);
-      return true;
-    } catch {
-      return false;
+  const canDrawCheckGlyph = font.hasGlyph(CHECK_MARK.codePointAt(0)!);
+
+  const warnUnsupported = (fieldId: string, text: string) => {
+    const missing = font.unsupportedChars(text);
+    if (missing.length) {
+      warnings.push(`${fieldId}: character(s) not in the embedded fonts: ${missing.join(' ')}`);
     }
-  })();
+  };
 
   const drawTextInRect = (
     page: PDFPage,
@@ -62,6 +68,7 @@ export async function fillPdf(
     opts: { size: number; minSize: number; align: 'left' | 'center'; padX: number; nudge: number }
   ) => {
     if (text === '') return;
+    warnUnsupported(fieldId, text);
     const padX = Math.min(opts.padX, rect.w * 0.15); // tiny boxes keep usable width
     const maxWidth = rect.w - 2 * padX;
     const { size, fits } = fitSize(font, text, maxWidth, opts.size, opts.minSize);
@@ -69,7 +76,7 @@ export async function fillPdf(
     const width = font.widthOfTextAtSize(text, size);
     const x = opts.align === 'center' ? rect.x + (rect.w - width) / 2 : rect.x + padX;
     const y = centeredBaseline(font, rect, size, opts.nudge);
-    page.drawText(text, { x, y, size, font });
+    font.drawText(page, text, { x, y, size });
   };
 
   const drawCheck = (page: PDFPage, gap: Rect) => {
@@ -78,7 +85,7 @@ export async function fillPdf(
       const width = font.widthOfTextAtSize(CHECK_MARK, size);
       const x = gap.x + (gap.w - width) / 2;
       const y = centeredBaseline(font, gap, size);
-      page.drawText(CHECK_MARK, { x, y, size, font });
+      font.drawText(page, CHECK_MARK, { x, y, size });
     } else {
       // vector fallback: ✓ strokes inside the gap
       const x0 = gap.x + gap.w * 0.15;
@@ -112,6 +119,7 @@ export async function fillPdf(
       }
       case 'multiline': {
         if (typeof value !== 'string' || value.trim() === '') return;
+        warnUnsupported(field.id, value);
         const layout = layoutMultiline(font, value.trim(), field.rect, {
           size: field.font.size,
           minSize: field.font.minSize,
@@ -124,11 +132,10 @@ export async function fillPdf(
         }
         layout.lines.forEach((line, i) => {
           if (line === '') return;
-          page.drawText(line, {
+          font.drawText(page, line, {
             x: field.rect.x + 2,
             y: layout.baselines[i],
             size: layout.size,
-            font,
           });
         });
         break;

--- a/src/lib/korea-visa/fill/fontSet.ts
+++ b/src/lib/korea-visa/fill/fontSet.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-character font fallback for the fill engine. The primary font (Noto
+ * Sans KR) lacks Japanese shinjitai glyphs (戸, 込, 渋 …); characters it
+ * can't draw fall back to the next font that can. Text is split into
+ * same-font runs, measured as the sum of run widths, and drawn run by run —
+ * so fitSize/wrap math and the ink on the page always agree.
+ */
+import type { PDFFont, PDFPage } from 'pdf-lib';
+import * as fontkit from 'fontkit';
+import type { FontMetrics } from './layout';
+
+interface Coverage {
+  hasGlyphForCodePoint(cp: number): boolean;
+}
+
+// Keyed by the exact bytes object (the hook caches and reuses it), so each
+// font is parsed for cmap lookups once per session, not once per fill.
+const coverageCache = new WeakMap<Uint8Array, Coverage>();
+
+export function coverageFor(bytes: Uint8Array): Coverage {
+  const hit = coverageCache.get(bytes);
+  if (hit) return hit;
+  const font = (fontkit as unknown as { create(b: Uint8Array): Coverage }).create(bytes);
+  coverageCache.set(bytes, font);
+  return font;
+}
+
+export interface FontSetEntry {
+  font: PDFFont;
+  coverage: Coverage;
+}
+
+interface Run {
+  text: string;
+  font: PDFFont;
+}
+
+export class FontSet implements FontMetrics {
+  constructor(private readonly entries: FontSetEntry[]) {
+    if (entries.length === 0) throw new Error('FontSet needs at least one font');
+  }
+
+  /** Index of the first font covering cp; uncovered chars stay primary (0). */
+  private pick(cp: number): number {
+    for (let i = 0; i < this.entries.length; i++) {
+      if (this.entries[i].coverage.hasGlyphForCodePoint(cp)) return i;
+    }
+    return 0;
+  }
+
+  private runs(text: string): Run[] {
+    const runs: Run[] = [];
+    let current = -1;
+    for (const ch of text) {
+      const idx = this.pick(ch.codePointAt(0)!);
+      if (idx === current) {
+        runs[runs.length - 1].text += ch;
+      } else {
+        runs.push({ text: ch, font: this.entries[idx].font });
+        current = idx;
+      }
+    }
+    return runs;
+  }
+
+  hasGlyph(cp: number): boolean {
+    return this.entries.some((e) => e.coverage.hasGlyphForCodePoint(cp));
+  }
+
+  /** Unique characters no font in the set can draw (they render as tofu). */
+  unsupportedChars(text: string): string[] {
+    const missing = new Set<string>();
+    for (const ch of text) {
+      if (!this.hasGlyph(ch.codePointAt(0)!)) missing.add(ch);
+    }
+    return [...missing];
+  }
+
+  widthOfTextAtSize(text: string, size: number): number {
+    let width = 0;
+    for (const run of this.runs(text)) width += run.font.widthOfTextAtSize(run.text, size);
+    return width;
+  }
+
+  // Vertical metrics come from the primary font; the Noto Sans KR/JP pair
+  // shares them, so mixed-run lines sit on one baseline.
+  heightAtSize(size: number, options?: { descender?: boolean }): number {
+    return this.entries[0].font.heightAtSize(size, options);
+  }
+
+  drawText(page: PDFPage, text: string, opts: { x: number; y: number; size: number }): void {
+    let x = opts.x;
+    for (const run of this.runs(text)) {
+      page.drawText(run.text, { x, y: opts.y, size: opts.size, font: run.font });
+      x += run.font.widthOfTextAtSize(run.text, opts.size);
+    }
+  }
+}

--- a/src/lib/korea-visa/fill/fonts.ts
+++ b/src/lib/korea-visa/fill/fonts.ts
@@ -1,12 +1,31 @@
 /**
- * The embedded fill font. Noto Sans KR covers Hangul + CJK ideographs +
- * kana + Latin + U+2713 (✓); it ships via npm and is copied to /public by
- * postinstall (copy-assets), so the browser and node read the same bytes.
+ * The embedded fill fonts. Noto Sans KR (primary) covers Hangul + Korean
+ * hanja + kana + Latin + U+2713 (✓), but Korean type carries only the
+ * traditional ideograph forms — Japanese shinjitai like 戸・込・渋 are
+ * absent and would draw as tofu. Noto Sans JP fills those gaps via
+ * per-character fallback (see fontSet.ts). Both fonts ship via npm and are
+ * copied to /public by postinstall (copy-assets), so the browser and node
+ * read the same bytes.
  */
-export const FONT_PUBLIC_PATH = '/fonts/NotoSansKR-Regular.ttf';
+export const PRIMARY_FONT_PUBLIC_PATH = '/fonts/NotoSansKR-Regular.ttf';
+export const JP_FALLBACK_FONT_PUBLIC_PATH = '/fonts/NotoSansJP-Regular.ttf';
 
-export async function loadFontBytes(): Promise<Uint8Array> {
-  const res = await fetch(FONT_PUBLIC_PATH);
-  if (!res.ok) throw new Error(`font fetch failed: ${res.status}`);
+export interface FillFontBytes {
+  primary: Uint8Array;
+  /** Tried in order for characters the primary font has no glyph for. */
+  fallbacks: Uint8Array[];
+}
+
+async function fetchBytes(path: string): Promise<Uint8Array> {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`font fetch failed: ${res.status} (${path})`);
   return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function loadFontBytes(): Promise<FillFontBytes> {
+  const [primary, jp] = await Promise.all([
+    fetchBytes(PRIMARY_FONT_PUBLIC_PATH),
+    fetchBytes(JP_FALLBACK_FONT_PUBLIC_PATH),
+  ]);
+  return { primary, fallbacks: [jp] };
 }

--- a/src/lib/korea-visa/fill/useFilledPdf.ts
+++ b/src/lib/korea-visa/fill/useFilledPdf.ts
@@ -10,7 +10,9 @@ import type { FormTemplate, FormValues } from '../template/schema';
 import { fillPdf } from './fillPdf';
 import { loadFontBytes } from './fonts';
 
-let fontCache: Promise<Uint8Array> | null = null;
+import type { FillFontBytes } from './fonts';
+
+let fontCache: Promise<FillFontBytes> | null = null;
 const getFont = () => (fontCache ??= loadFontBytes());
 
 export function useFilledPdf(


### PR DESCRIPTION
## Summary

Two fixes for the Korea visa tool:

**1. Header nav was missing the `/korea-visa` link**
The tool shipped with a home card, sitemap entry, and llms.txt listing, but `HeaderNav`'s `NAV_ITEMS` never got the entry. Added `韓国ビザ` at the end, matching the home grid ordering.

**2. Japanese shinjitai rendered as mojibake in the filled PDF** (user-reported: 「戸」)
The fill engine embedded only Noto Sans KR, which carries just the traditional ideograph forms Korean typography uses (戶) — Japanese shinjitai like 戸・込・渋・対・働・斎 are absent from its cmap and drew as tofu.

- Embed Noto Sans JP alongside KR (`@expo-google-fonts/noto-sans-jp`, same channel as the KR font; copied to `/public/fonts/` by postinstall)
- New `fontSet.ts`: text splits into per-character runs by cmap coverage; each run measures and draws with the first font that covers it (KR primary, so Hangul is unaffected). `fitSize`/wrap math sums run widths, so layout and ink stay in agreement
- Characters no embedded font covers now surface a field warning instead of failing silently

## Verification

- `npm run verify:korea-visa` gains a mixed KR/JP probe (`江戸込渋`) that must survive pdf.js text extraction — all 8 checks pass
- Rendering confirmed pixel-level in real Chromium + pdf.js (the production preview stack): all four probe glyphs draw correctly, no page regressions
- All 21 korea-visa jest tests pass; `next build` passes
- Pre-existing failures unrelated to this diff: 3 shipping test suites (require seeded DB), 2 lint errors in `BreakTimer`/`ProgressBar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTHSr6QRyw8k6y1Pocwm8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTHSr6QRyw8k6y1Pocwm8u)_