### PR TITLE
korea-visa: keep toolbar and preview pinned while scrolling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ CLAUDE.md
 # Korea visa tool: assets copied from node_modules by scripts/copy-assets.mts
 /public/pdf.worker.min.mjs
 /public/fonts/
+.gstack/

--- a/src/components/KoreaVisa/KoreaVisaTool.tsx
+++ b/src/components/KoreaVisa/KoreaVisaTool.tsx
@@ -154,7 +154,11 @@ export function KoreaVisaTool() {
               the PDF — check your connection and edit a field to retry: {fillError}
             </div>
           )}
-          <div className="mb-4 flex flex-wrap items-center gap-2 text-sm" data-testid="toolbar">
+          {/* Sticky below the site header (h-16) so download/clear stay reachable while scrolling the long form. */}
+          <div
+            className="sticky top-16 z-30 -mx-4 mb-4 flex flex-wrap items-center gap-2 border-b border-neutral-200 bg-gray-50/95 px-4 py-2.5 text-sm backdrop-blur"
+            data-testid="toolbar"
+          >
             {s.downloadNoticeVisible && (
               <span
                 data-testid="download-notice"
@@ -217,7 +221,8 @@ export function KoreaVisaTool() {
                 onChange={s.setValue}
               />
             </div>
-            <div className="lg:sticky lg:top-6 lg:self-start">
+            {/* top clears the sticky header (64px) + toolbar (~45px) so the page tabs stay visible too. */}
+            <div className="lg:sticky lg:top-32 lg:self-start">
               <PdfPreview
                 bytes={filledBytes}
                 pageCount={s.template.pdf.pageCount}


### PR DESCRIPTION
## Summary

User request: the すべてクリア / Download filled PDF bar (and the preview's page tabs) should stay visible while scrolling the long form.

- Toolbar (`data-testid="toolbar"`) is now `sticky top-16 z-30` — pinned directly below the sticky site header (h-16), full-bleed across the content gutters with the page background (`bg-gray-50/95` + backdrop-blur) and a bottom border so form content slides under it cleanly. Status chips (download notice, draft restored, overflow warnings) ride along.
- Preview column sticky offset moves `lg:top-6` → `lg:top-32` so the page tabs and PDF preview sit below the header + toolbar instead of sliding under them.
- Also folds in a one-line `.gitignore` entry for `.gstack/` QA artifacts.

## Verification

- Browser-verified at 1280×720 and 375×812: toolbar pins at exactly y=64 under the header at scroll depths 1500px and 4000px; download button passes an `elementFromPoint` hit-test while pinned; page tabs remain visible on desktop. No console errors.
- 21/21 korea-visa jest tests pass; eslint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)